### PR TITLE
Yaml >=5.4 instead of ^5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
   "require": {
     "php": ">=7.4",
     "cweagans/composer-patches": "^1.7",
-    "symfony/yaml": "^5.4"
+    "symfony/yaml": ">=5.4"
   },
   "require-dev": {
     "php": ">=7.4",


### PR DESCRIPTION
Per email "Compatibility Request: Support for Symfony 6.4 in `forumone/wp-cfm`"